### PR TITLE
Add referenced artifacts to both assets

### DIFF
--- a/asset_119_pmsf_adc_cutout_sensordata/manifest_reference.json
+++ b/asset_119_pmsf_adc_cutout_sensordata/manifest_reference.json
@@ -358,5 +358,48 @@
         }
       }
     ],
-    "manifest:hasReferencedArtifacts": []
+    "manifest:hasReferencedArtifacts": [
+      {
+        "@type": "manifest:Link",
+        "manifest:iri": {
+          "@id": "did:web:registry.gaia-x.eu:OSITrace:DjHgK5ErTBow1Ya3J05tW9l12skGWgZn6kA9"
+        },
+        "skos:note": {
+          "@value": "Referenced OSITrace Simulation Asset from <https://github.com/GAIA-X4PLC-AAD/ositrace-asset-example>.",
+          "@type": "xsd:string"
+        },
+        "sh:conformsTo": [
+          {
+            "@id": "https://ontologies.envited-x.net/ositrace/v4/ontology"
+          }
+        ],
+        "manifest:hasAccessRole": {
+          "@type": "manifest:AccessRole",
+          "@id": "envited-x:isPublic"
+        },
+        "manifest:hasCategory": {
+          "@type": "manifest:Category",
+          "@id": "envited-x:isReferencedSimulationData"
+        },
+        "manifest:hasFileMetadata": {
+          "@type": "manifest:FileMetadata",
+          "manifest:filePath": {
+            "@value": "https://github.com/GAIA-X4PLC-AAD/ositrace-asset-example/releases/download/v0.0.1/asset_119_pmsf_adc_cutout_sensorview.zip",
+            "@type": "xsd:anyURI"
+          },
+          "manifest:mimeType": {
+            "@value": "application/zip",
+            "@type": "xsd:string"
+          },
+          "manifest:fileSize": {
+            "@value": 41036692,
+            "@type": "xsd:integer"
+          },
+          "manifest:filename": {
+            "@value": "asset_119_pmsf_adc_cutout_sensorview.zip",
+            "@type": "xsd:string"
+          }
+        }
+      }
+    ]
   }

--- a/asset_119_pmsf_adc_cutout_sensorview/manifest_reference.json
+++ b/asset_119_pmsf_adc_cutout_sensorview/manifest_reference.json
@@ -268,5 +268,48 @@
         }
       }
     ],
-    "manifest:hasReferencedArtifacts": []
+    "manifest:hasReferencedArtifacts": [
+      {
+        "@type": "manifest:Link",
+        "manifest:iri": {
+          "@id": "did:web:registry.gaia-x.eu:OSITrace:DjHgK5ErTBow1Ya3J05tW9l12skGWgZn6kA9"
+        },
+        "skos:note": {
+          "@value": "Referenced OSITrace Simulation Asset from <https://github.com/GAIA-X4PLC-AAD/ositrace-asset-example>.",
+          "@type": "xsd:string"
+        },
+        "sh:conformsTo": [
+          {
+            "@id": "https://ontologies.envited-x.net/ositrace/v4/ontology"
+          }
+        ],
+        "manifest:hasAccessRole": {
+          "@type": "manifest:AccessRole",
+          "@id": "envited-x:isPublic"
+        },
+        "manifest:hasCategory": {
+          "@type": "manifest:Category",
+          "@id": "envited-x:isReferencedSimulationData"
+        },
+        "manifest:hasFileMetadata": {
+          "@type": "manifest:FileMetadata",
+          "manifest:filePath": {
+            "@value": "https://github.com/GAIA-X4PLC-AAD/ositrace-asset-example/releases/download/v0.0.1/asset_119_pmsf_adc_cutout_sensordata.zip",
+            "@type": "xsd:anyURI"
+          },
+          "manifest:mimeType": {
+            "@value": "application/zip",
+            "@type": "xsd:string"
+          },
+          "manifest:fileSize": {
+            "@value": 52774127,
+            "@type": "xsd:integer"
+          },
+          "manifest:filename": {
+            "@value": "asset_119_pmsf_adc_cutout_sensordata.zip",
+            "@type": "xsd:string"
+          }
+        }
+      }
+    ]
   }


### PR DESCRIPTION
Reference each other as referenced artifact.

@jdsika Problem: Both assets are released at the same time, so referencing each other involves predicting the actual current version's download link of the zipped asset.

In this PR, the "old" v0.0.1 is referenced. The download link should be quite predictable but the zip size is probably not.